### PR TITLE
ReadmeのCardTable修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@
 ## cardsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|credit_num|integer|null: false|
-|limit_month|integer|null: false|
-|limit_year|string|null: false|
-|security|string|null: false|
-|user|references|foreign_key: true|
+|customer_id|string|null: false|
+|card_id|string|null: false|
+|user_id|references|foreign_key: true|
 ### Association
 - belongs_to :user
 
@@ -58,7 +56,7 @@
 |area|references|null: false, foreign_key: true|
 |shipping_day|references|null: false, foreign_key: true|
 |price|integer|null: false|
-|user|references|null: false, foreign_key: true|
+|user_seller|references|null: false, foreign_key: true|
 ### Association
 - has_many: images
 - has_many: comments
@@ -134,7 +132,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |message|text|null: false|
-|user|references|foreign_key: true|
+|user_buyer|references|foreign_key: true|
 |item|references|foreign_key: true|
 ### Association
 - belongs_to :user


### PR DESCRIPTION
# What（どのような実装をしているのか）
## README修正
cardsテーブルから個人情報を消去し、「Payjp」で管理ための、下記3点へ修正
・customer_id
・card_id
・user_id

# Why（なぜこの実装が必要なのか）
フリマアプリのカード情報をDBに保存せず「payjp」を使用するため。