### PR TITLE
application.scssの修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,7 @@
 @import "modules/homes";
 @import "font-awesome-sprockets";
 @import "font-awesome";
-@import "purchase";
+@import "modules/purchase";
 @import "modules/signup";
 @import "modules/signup-address";
 @import "modules/login";


### PR DESCRIPTION
[What]application.scssの"purchase"を"modules/purchase"に修正。

[Why]エラーが発生するため。