### PR TITLE
トップページから商品出品画面へのリンクを設定

### DIFF
--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -1,5 +1,5 @@
 .index
-  = link_to "#" do
+  = link_to sell_item_index_path do
     .index__camera
       %span.index__camera__text
         = "出品する"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
     post 'addresses', to: 'users/registrations#create_address'
   end
   root to: 'homes#index'
+
+  resources :sell_item do
+  end
   # resources :purchase, only: [:index]
   # root 'users#index'
   resources :products, only: :show


### PR DESCRIPTION
[What]トップページのリンクを設定し、トップページから商品出品ページへ遷移出来るように対応。

[Why]必要な機能であるため、作業の効率化を進めるため