### PR TITLE
売却後の商品詳細画面の表示の修正

### DIFF
--- a/app/views/products/_show-main.html.haml
+++ b/app/views/products/_show-main.html.haml
@@ -119,7 +119,8 @@
             %button.main__showMain__topContents__topContent__commentBox__newComment__commentBtn{type:"submit"}
               %i.fas.fa-comment
               コメントする
-        - if user_signed_in? && current_user.id == @product.user_id
+        - if @product.status == 1
+        - elsif user_signed_in? && current_user.id == @product.user_id
           .productsManage
             = link_to edit_product_path , class:"editBtn" do
               %i.far.fa-edit
@@ -127,7 +128,7 @@
             = link_to product_path,method: :delete, data: { confirm: "本当に削除しますか？"}, class:"deleteBtn" do
               %i.fas.fa-trash
                 削除する
-        - if user_signed_in? && current_user.id != @product.user_id
+        - elsif user_signed_in? && current_user.id != @product.user_id
           .productsManage
             = link_to product_purchases_path(@product), class:"buyBtn" do
               %i.fas.fa-shopping-cart


### PR DESCRIPTION
[What]売却後商品詳細画面を修正。売却は、出品者は、編集、削除ボタンが押せないこと。出品者以外は購入ボタンが押せないように修正

[Why]購入後、ユーザーが誤った作業をしないようにするため。